### PR TITLE
New indents broke rc.local md5sum, startup script

### DIFF
--- a/pishrink.sh
+++ b/pishrink.sh
@@ -63,11 +63,12 @@ if [ "$should_skip_autoexpand" = false ]; then
   if [ `md5sum $mountdir/etc/rc.local | cut -d ' ' -f 1` != "a27a4d8192ea6ba713d2ddd15a55b1df" ]; then
     echo Creating new /etc/rc.local
     mv $mountdir/etc/rc.local $mountdir/etc/rc.local.bak
+    #Do not touch the following 6 lines including EOF. The md5sum check above depends on having the extact same bytes.
     cat <<\EOF > $mountdir/etc/rc.local
-    #!/bin/bash
-    /usr/bin/raspi-config --expand-rootfs
-    rm -f /etc/rc.local; cp -f /etc/rc.local.bak /etc/rc.local; reboot
-    exit 0
+#!/bin/bash
+/usr/bin/raspi-config --expand-rootfs
+rm -f /etc/rc.local; cp -f /etc/rc.local.bak /etc/rc.local; reboot
+exit 0
 EOF
     chmod +x $mountdir/etc/rc.local
   fi


### PR DESCRIPTION
The indentation was introduced in cad2e0e11a9321cec88534a5537fe3157f522f0b, not when the safety hash check was added in 2c6f069c2f5092616a9e60677d6ea056c8b292a6, my first guess.
The indentations makes the rc.local begin with spaces instead of `#!/bin/bash` and will not run. But it gets better.
The md5 safety check is based on rc.local without indents, so after the added indentations the if-block will never be skipped. If the script is run a second time, the original rc.local backed up in rc.local.bak will be overwritten, and on boot result in a never ending loop, trying to expand the filesystem each time. A user could run the pishrink.sh a second time on a disk image, e.g. after making more edits.
